### PR TITLE
Adjust form spacing and padding

### DIFF
--- a/src/components/SessionStatsFull/sections/SessionConfigSection.tsx
+++ b/src/components/SessionStatsFull/sections/SessionConfigSection.tsx
@@ -33,7 +33,7 @@ export const SessionConfigSection = ({
     <div className="w-full max-w-2xl mx-auto" id="session-config">
       <SectionHeader section={section} />
 
-      <div className="mt-8 space-y-6">
+      <div className="mt-4 space-y-4">
         {/* Training Assignment */}
         <div className="space-y-2">
           <BaseLabelRequired>Training Assignment</BaseLabelRequired>
@@ -42,7 +42,7 @@ export const SessionConfigSection = ({
             <select
               value={sessionData.assignment_id}
               onChange={(e) => updateSessionData("assignment_id", e.target.value)}
-              className={`w-full h-12 px-4 rounded-xl border-2 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+              className={`w-full h-10 px-4 rounded-xl border-2 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 ${
                 theme === "dark"
                   ? "bg-zinc-900 border-zinc-800 text-white focus:border-indigo-500 focus:ring-indigo-500/20"
                   : "bg-white border-gray-200 focus:border-indigo-500 focus:ring-indigo-500/20"

--- a/src/views/sessionStatsFull.tsx
+++ b/src/views/sessionStatsFull.tsx
@@ -76,7 +76,7 @@ export default function ImprovedSessionStats() {
   }
 
   return (
-    <div className={`min-h-screen ${theme === "dark" ? "bg-[#0a0a0a]" : "bg-white"} relative`}>
+    <div className={`min-h-[100dvh] ${theme === "dark" ? "bg-[#0a0a0a]" : "bg-white"} relative`}>
       {/* Progress Indicator - Fixed on larger screens, hidden on mobile */}
       <div className="hidden lg:block">
         <ScrollProgress activeSection={activeSection} totalSections={sections.length} />
@@ -108,10 +108,10 @@ export default function ImprovedSessionStats() {
       </div>
 
       {/* Main Content Container */}
-      <div className="w-full h-screen overflow-y-auto snap-y snap-mandatory scroll-smooth lg:pt-0 " onScroll={handleScroll}>
+      <div className="w-full h-[100dvh] overflow-y-auto snap-y snap-proximity scroll-smooth lg:pt-0" onScroll={handleScroll}>
         {/* Section 1: Session Configuration */}
-        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8 ">
-          <div className="w-full max-w-4xl  py-8">
+        <section className="min-h-[100dvh] snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8 ">
+          <div className="w-full max-w-4xl h-full overflow-y-auto py-8">
             <SessionConfigSection
               section={sections[0]}
               sessionData={sessionData}
@@ -123,8 +123,8 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 2: Participants */}
-        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
-          <div className="w-full max-w-4xl">
+        <section className="min-h-[100dvh] snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+          <div className="w-full max-w-4xl h-full overflow-y-auto">
             <ParticipantsSection
               section={sections[1]}
               participants={participants}
@@ -141,8 +141,8 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 3: Targets */}
-        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
-          <div className="w-full max-w-4xl">
+        <section className="min-h-[100dvh] snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+          <div className="w-full max-w-4xl h-full overflow-y-auto">
             <TargetsSection
               section={sections[2]}
               targets={targets}
@@ -154,15 +154,15 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 4: Engagements */}
-        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
-          <div className="w-full max-w-4xl">
+        <section className="min-h-[100dvh] snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+          <div className="w-full max-w-4xl h-full overflow-y-auto">
             <EngagementsSection section={sections[3]} targets={targets} participants={participants} updateEngagement={updateEngagement} />
           </div>
         </section>
 
         {/* Section 5: Summary */}
-        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
-          <div className="w-full max-w-4xl">
+        <section className="min-h-[100dvh] snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+          <div className="w-full max-w-4xl h-full overflow-y-auto">
             <SummarySection
               section={sections[4]}
               participants={participants}

--- a/src/views/sessionStatsFull.tsx
+++ b/src/views/sessionStatsFull.tsx
@@ -110,7 +110,7 @@ export default function ImprovedSessionStats() {
       {/* Main Content Container */}
       <div className="w-full h-screen overflow-y-auto snap-y snap-mandatory scroll-smooth lg:pt-0 " onScroll={handleScroll}>
         {/* Section 1: Session Configuration */}
-        <section className="min-h-screen snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8 ">
+        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8 ">
           <div className="w-full max-w-4xl  py-8">
             <SessionConfigSection
               section={sections[0]}
@@ -123,7 +123,7 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 2: Participants */}
-        <section className="min-h-screen snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
           <div className="w-full max-w-4xl">
             <ParticipantsSection
               section={sections[1]}
@@ -141,7 +141,7 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 3: Targets */}
-        <section className="min-h-screen snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
           <div className="w-full max-w-4xl">
             <TargetsSection
               section={sections[2]}
@@ -154,14 +154,14 @@ export default function ImprovedSessionStats() {
         </section>
 
         {/* Section 4: Engagements */}
-        <section className="min-h-screen snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
           <div className="w-full max-w-4xl">
             <EngagementsSection section={sections[3]} targets={targets} participants={participants} updateEngagement={updateEngagement} />
           </div>
         </section>
 
         {/* Section 5: Summary */}
-        <section className="min-h-screen snap-start flex py-16 justify-center px-4 sm:px-6 lg:px-8">
+        <section className="min-h-screen snap-start flex py-10 justify-center px-4 sm:px-6 lg:px-8">
           <div className="w-full max-w-4xl">
             <SummarySection
               section={sections[4]}


### PR DESCRIPTION
Adjusts spacing in the full-page form to reduce header gap, even section spacing, and compact form elements.

The changes reduce the vertical padding of all snap-scroll sections (`py-16` to `py-10`) to bring section headers closer to the top, and also compact the form elements within the Session Configuration section by reducing top margin (`mt-8` to `mt-4`), element spacing (`space-y-6` to `space-y-4`), and the height/padding of the assignment select field (`h-12` to `h-10`).

---
<a href="https://cursor.com/background-agent?bcId=bc-e13d62a0-e857-4c34-9327-d56b662aa03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e13d62a0-e857-4c34-9327-d56b662aa03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

