### PR TITLE
Add motion enum to grouping type

### DIFF
--- a/supabase/migrations/20250115_add_motion_to_grouping_type_enum.sql
+++ b/supabase/migrations/20250115_add_motion_to_grouping_type_enum.sql
@@ -1,0 +1,31 @@
+-- =====================================================
+-- ADD 'motion' VALUE TO grouping_type_enum
+-- =====================================================
+-- This migration adds a new value 'motion' to the existing
+-- grouping_type_enum for use in grouping score selection
+-- =====================================================
+
+-- Add 'motion' value to the grouping_type_enum
+-- This is safe to run multiple times as PostgreSQL will throw an error
+-- if the value already exists, but won't break the migration
+DO $$ 
+BEGIN
+    -- Check if 'motion' value doesn't already exist
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM pg_enum 
+        WHERE enumlabel = 'motion' 
+        AND enumtypid = (
+            SELECT oid 
+            FROM pg_type 
+            WHERE typname = 'grouping_type_enum'
+        )
+    ) THEN
+        -- Add the new value
+        ALTER TYPE grouping_type_enum ADD VALUE 'motion';
+    END IF;
+END $$;
+
+-- Add comment for documentation
+COMMENT ON TYPE grouping_type_enum IS 
+'Enum for grouping types including the new motion option for grouping score selection';

--- a/test_enum_migration.sql
+++ b/test_enum_migration.sql
@@ -1,0 +1,8 @@
+-- Test script to verify the grouping_type_enum migration
+-- This can be run in Supabase SQL editor to test
+
+-- First, check if the enum exists and show current values
+SELECT unnest(enum_range(NULL::grouping_type_enum)) AS current_values;
+
+-- The migration will add 'motion' to this list
+-- After running the migration, this query should show 'motion' in the results


### PR DESCRIPTION
Add 'motion' value to `grouping_type_enum` to enable it as a new option for grouping score selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-a89ba3c4-0a89-491e-b03b-b7f45c145db3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a89ba3c4-0a89-491e-b03b-b7f45c145db3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

