### PR TITLE
Add motion to ad groupings and check SuperBase

### DIFF
--- a/src/components/TrainingPageScoreFormModal/TrainingPageGroupFormModal.tsx
+++ b/src/components/TrainingPageScoreFormModal/TrainingPageGroupFormModal.tsx
@@ -32,7 +32,7 @@ const groupScoreSchema = z.object({
   shooting_position: z.string().min(1, "Shooting position is required"),
   effort: z.boolean(),
   day_period: z.enum(["day", "night"]),
-  type: z.enum(["normal", "timed", "position_abandonment"]),
+  type: z.enum(["normal", "timed", "position_abandonment", "motion"]),
 });
 
 type GroupScoreFormValues = z.infer<typeof groupScoreSchema>;
@@ -263,6 +263,7 @@ export default function TrainingPageGroupFormModal({ isOpen, onClose, onSubmit, 
                 { value: "normal", label: "Normal" },
                 { value: "timed", label: "Timed" },
                 { value: "position_abandonment", label: "Position Abandonment" },
+                { value: "motion", label: "Motion" },
               ]}
               disabled={isSubmitting}
             />


### PR DESCRIPTION
Add "motion" as a new type option for ad groupings in the TrainingPageGroupFormModal.

This PR updates the frontend schema and UI to include "motion" as a selectable type for ad groupings. Note that the corresponding Supabase database enum `grouping_type_enum` will need to be updated separately for full functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-adedc571-36e5-4657-be9f-a50a04e27088">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adedc571-36e5-4657-be9f-a50a04e27088">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

